### PR TITLE
OnlineStoreDB: Docker, schema, seed, order ops, and docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Normalize to LF for repo; Windows will still check out CRLF if needed
+* text=auto eol=lf
+
+# Explicit LF for cross-platform scripts/config
+*.sql  text eol=lf
+*.sh   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.md   text eol=lf
+
+# Explicit CRLF for Windows batch files
+*.bat  text eol=crlf
+*.cmd  text eol=crlf

--- a/README.md
+++ b/README.md
@@ -63,3 +63,59 @@ erDiagram
     decimal UnitPrice
     decimal Subtotal
   }
+
+---
+
+## 🧪 Quickstart (Docker)
+```bash
+set +H
+export SA_PASSWORD='YourStrong!Passw0rd'
+docker compose -f docker/docker-compose.yml up -d
+# then run the SQL in /sql (schema, procs, triggers, views, seed)
+
+```
+🗺️ ER Diagram (Mermaid)
+erDiagram
+  CUSTOMERS ||--o{ ORDERS : places
+  ORDERS ||--o{ ORDERDETAILS : has
+  PRODUCTS ||--o{ ORDERDETAILS : contains
+
+  CUSTOMERS {
+    int CustomerID PK
+    string Name
+    string Email
+    string Address
+    datetime CreatedAt
+    datetime UpdatedAt
+  }
+
+  PRODUCTS {
+    int ProductID PK
+    string Name
+    decimal Price
+    int StockQuantity
+    datetime CreatedAt
+    datetime UpdatedAt
+  }
+
+  ORDERS {
+    int OrderID PK
+    int CustomerID FK
+    datetime OrderDate
+    string Status
+    decimal TotalAmount
+    datetime CreatedAt
+    datetime UpdatedAt
+  }
+
+  ORDERDETAILS {
+    int OrderDetailID PK
+    int OrderID FK
+    int ProductID FK
+    int Quantity
+    decimal UnitPrice
+    decimal Subtotal "computed: Quantity*UnitPrice"
+    datetime CreatedAt
+    datetime UpdatedAt
+  }
+

--- a/data/customers.csv
+++ b/data/customers.csv
@@ -1,0 +1,6 @@
+CustomerID,Name,Email,Address
+1,Avery Johnson,avery.johnson@example.com,101 Maple St, Davidson NC
+2,Jordan Lee,jordan.lee@example.com,22 Cedar Ave, Mooresville NC
+3,Casey Nguyen,casey.nguyen@example.com,900 Lakeview Dr, Huntersville NC
+4,Riley Patel,riley.patel@example.com,77 Main St, Charlotte NC
+5,Skylar Kim,skylar.kim@example.com,45 Oak Rd, Cornelius NC

--- a/data/order_details.csv
+++ b/data/order_details.csv
@@ -1,0 +1,6 @@
+OrderDetailID,OrderID,ProductID,Quantity,UnitPrice
+1,1,1,2,19.99
+2,1,3,1,8.99
+3,2,2,1,89.50
+4,2,5,1,34.95
+5,3,6,1,149.99

--- a/data/orders.csv
+++ b/data/orders.csv
@@ -1,0 +1,4 @@
+OrderID,CustomerID,OrderDate,TotalAmount
+1,1,2025-09-10T14:00:00Z,0
+2,2,2025-09-11T16:30:00Z,0
+3,3,2025-09-12T12:05:00Z,0

--- a/data/products.csv
+++ b/data/products.csv
@@ -1,0 +1,7 @@
+ProductID,Name,Price,StockQuantity
+1,Wireless Mouse,19.99,120
+2,Mechanical Keyboard,89.50,60
+3,USB-C Cable 1m,8.99,300
+4,27" 4K Monitor,279.00,25
+5,Laptop Stand,34.95,80
+6,Noise-Cancelling Headphones,149.99,40

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  store-mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: store-mssql
+    ports:
+      - "1435:1433"
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=${SA_PASSWORD}
+    healthcheck:
+      test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-C", "-S", "localhost", "-U", "SA", "-P", "${SA_PASSWORD}", "-Q", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - mssql-data:/var/opt/mssql
+      - ../sql:/var/opt/sql
+      - ../data:/var/opt/data
+volumes:
+  mssql-data:

--- a/scripts/dev-status.bat
+++ b/scripts/dev-status.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+docker ps --filter "name=store-mssql"
+echo.
+docker exec -i store-mssql /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P "YourStrong!Passw0rd" -d OnlineStoreDB -Q "SET NOCOUNT ON;
+SELECT COUNT() AS Customers FROM dbo.Customers;
+SELECT COUNT() AS Products FROM dbo.Products;
+SELECT COUNT(*) AS Orders FROM dbo.Orders;
+SELECT TOP 5 * FROM dbo.vwOrderSummaryWithStatus ORDER BY OrderID DESC;"
+endlocal

--- a/sql/01_schema.sql
+++ b/sql/01_schema.sql
@@ -1,0 +1,66 @@
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+IF DB_ID('OnlineStoreDB') IS NULL
+  CREATE DATABASE OnlineStoreDB;
+GO
+USE OnlineStoreDB;
+GO
+
+IF OBJECT_ID('dbo.OrderDetails','U') IS NOT NULL DROP TABLE dbo.OrderDetails;
+IF OBJECT_ID('dbo.Orders','U')        IS NOT NULL DROP TABLE dbo.Orders;
+IF OBJECT_ID('dbo.Products','U')      IS NOT NULL DROP TABLE dbo.Products;
+IF OBJECT_ID('dbo.Customers','U')     IS NOT NULL DROP TABLE dbo.Customers;
+GO
+
+CREATE TABLE dbo.Customers(
+  CustomerID     INT IDENTITY(1,1) PRIMARY KEY,
+  Name           NVARCHAR(100) NOT NULL,
+  Email          NVARCHAR(255) NOT NULL UNIQUE,
+  Address        NVARCHAR(255) NULL,
+  CreatedAt      DATETIME2(0)  NOT NULL CONSTRAINT DF_Customers_CreatedAt DEFAULT SYSUTCDATETIME(),
+  UpdatedAt      DATETIME2(0)  NOT NULL CONSTRAINT DF_Customers_UpdatedAt DEFAULT SYSUTCDATETIME()
+);
+GO
+
+CREATE TABLE dbo.Products(
+  ProductID      INT IDENTITY(1,1) PRIMARY KEY,
+  Name           NVARCHAR(150) NOT NULL,
+  Price          DECIMAL(10,2) NOT NULL CHECK (Price >= 0),
+  StockQuantity  INT NOT NULL CHECK (StockQuantity >= 0),
+  CreatedAt      DATETIME2(0)  NOT NULL CONSTRAINT DF_Products_CreatedAt DEFAULT SYSUTCDATETIME(),
+  UpdatedAt      DATETIME2(0)  NOT NULL CONSTRAINT DF_Products_UpdatedAt DEFAULT SYSUTCDATETIME()
+);
+GO
+
+CREATE TABLE dbo.Orders(
+  OrderID        INT IDENTITY(1,1) PRIMARY KEY,
+  CustomerID     INT NOT NULL,
+  OrderDate      DATETIME2(0) NOT NULL CONSTRAINT DF_Orders_OrderDate DEFAULT SYSUTCDATETIME(),
+  TotalAmount    DECIMAL(12,2) NOT NULL CONSTRAINT DF_Orders_Total DEFAULT 0,
+  CreatedAt      DATETIME2(0)  NOT NULL CONSTRAINT DF_Orders_CreatedAt DEFAULT SYSUTCDATETIME(),
+  UpdatedAt      DATETIME2(0)  NOT NULL CONSTRAINT DF_Orders_UpdatedAt DEFAULT SYSUTCDATETIME(),
+  CONSTRAINT FK_Orders_Customers FOREIGN KEY (CustomerID) REFERENCES dbo.Customers(CustomerID)
+);
+GO
+
+CREATE TABLE dbo.OrderDetails(
+  OrderDetailID  INT IDENTITY(1,1) PRIMARY KEY,
+  OrderID        INT NOT NULL,
+  ProductID      INT NOT NULL,
+  Quantity       INT NOT NULL CHECK (Quantity > 0),
+  UnitPrice      DECIMAL(10,2) NOT NULL CHECK (UnitPrice >= 0),
+  Subtotal       AS (Quantity * UnitPrice) PERSISTED,
+  CreatedAt      DATETIME2(0) NOT NULL CONSTRAINT DF_OrderDetails_CreatedAt DEFAULT SYSUTCDATETIME(),
+  UpdatedAt      DATETIME2(0) NOT NULL CONSTRAINT DF_OrderDetails_UpdatedAt DEFAULT SYSUTCDATETIME(),
+  CONSTRAINT FK_OrderDetails_Orders   FOREIGN KEY (OrderID)   REFERENCES dbo.Orders(OrderID),
+  CONSTRAINT FK_OrderDetails_Products FOREIGN KEY (ProductID) REFERENCES dbo.Products(ProductID)
+);
+GO
+
+CREATE INDEX IX_Orders_CustomerID_OrderDate ON dbo.Orders(CustomerID, OrderDate DESC);
+CREATE INDEX IX_OrderDetails_OrderID ON dbo.OrderDetails(OrderID);
+CREATE INDEX IX_OrderDetails_ProductID ON dbo.OrderDetails(ProductID);
+CREATE INDEX IX_Products_Name ON dbo.Products(Name);
+GO

--- a/sql/02_seed.sql
+++ b/sql/02_seed.sql
@@ -1,0 +1,38 @@
+USE OnlineStoreDB;
+GO
+
+/* Minimal seed using explicit values (keeps it portable for Docker demo)
+   (IDs match CSVs for consistency) */
+
+SET IDENTITY_INSERT dbo.Customers ON;
+INSERT INTO dbo.Customers(CustomerID, Name, Email, Address, CreatedAt, UpdatedAt) VALUES
+(1,'Avery Johnson','avery.johnson@example.com','101 Maple St, Davidson NC', SYSUTCDATETIME(), SYSUTCDATETIME()),
+(2,'Jordan Lee','jordan.lee@example.com','22 Cedar Ave, Mooresville NC', SYSUTCDATETIME(), SYSUTCDATETIME()),
+(3,'Casey Nguyen','casey.nguyen@example.com','900 Lakeview Dr, Huntersville NC', SYSUTCDATETIME(), SYSUTCDATETIME()),
+(4,'Riley Patel','riley.patel@example.com','77 Main St, Charlotte NC', SYSUTCDATETIME(), SYSUTCDATETIME()),
+(5,'Skylar Kim','skylar.kim@example.com','45 Oak Rd, Cornelius NC', SYSUTCDATETIME(), SYSUTCDATETIME());
+SET IDENTITY_INSERT dbo.Customers OFF;
+
+SET IDENTITY_INSERT dbo.Products ON;
+INSERT INTO dbo.Products(ProductID, Name, Price, StockQuantity, CreatedAt, UpdatedAt) VALUES
+(1,'Wireless Mouse',19.99,120,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(2,'Mechanical Keyboard',89.50,60,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(3,'USB-C Cable 1m',8.99,300,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(4,'27\" 4K Monitor',279.00,25,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(5,'Laptop Stand',34.95,80,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(6,'Noise-Cancelling Headphones',149.99,40,SYSUTCDATETIME(),SYSUTCDATETIME());
+SET IDENTITY_INSERT dbo.Products OFF;
+
+SET IDENTITY_INSERT dbo.Orders ON;
+INSERT INTO dbo.Orders(OrderID, CustomerID, OrderDate, TotalAmount, CreatedAt, UpdatedAt) VALUES
+(1,1,'2025-09-10T14:00:00Z',0,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(2,2,'2025-09-11T16:30:00Z',0,SYSUTCDATETIME(),SYSUTCDATETIME()),
+(3,3,'2025-09-12T12:05:00Z',0,SYSUTCDATETIME(),SYSUTCDATETIME());
+SET IDENTITY_INSERT dbo.Orders OFF;
+
+/* Use proc to add detail lines to ensure totals & stock update */
+EXEC dbo.AddOrderItem @OrderID=1, @ProductID=1, @Quantity=2;  -- 2 * 19.99
+EXEC dbo.AddOrderItem @OrderID=1, @ProductID=3, @Quantity=1;  -- 1 * 8.99
+EXEC dbo.AddOrderItem @OrderID=2, @ProductID=2, @Quantity=1;  -- 1 * 89.50
+EXEC dbo.AddOrderItem @OrderID=2, @ProductID=5, @Quantity=1;  -- 1 * 34.95
+EXEC dbo.AddOrderItem @OrderID=3, @ProductID=6, @Quantity=1;  -- 1 * 149.99

--- a/sql/03_views.sql
+++ b/sql/03_views.sql
@@ -1,0 +1,28 @@
+USE OnlineStoreDB;
+GO
+
+CREATE OR ALTER VIEW dbo.vwOrderSummary AS
+  SELECT
+    o.OrderID,
+    o.CustomerID,
+    o.OrderDate,
+    o.TotalAmount,
+    COUNT(od.OrderDetailID) AS LineCount
+  FROM dbo.Orders o
+  LEFT JOIN dbo.OrderDetails od ON od.OrderID = o.OrderID
+  GROUP BY o.OrderID, o.CustomerID, o.OrderDate, o.TotalAmount;
+GO
+
+CREATE OR ALTER VIEW dbo.vwBestSellers30D AS
+  SELECT TOP 20
+    od.ProductID,
+    p.Name,
+    SUM(od.Quantity) AS UnitsSold,
+    SUM(od.Subtotal) AS Revenue
+  FROM dbo.OrderDetails od
+  JOIN dbo.Orders o   ON o.OrderID = od.OrderID
+  JOIN dbo.Products p ON p.ProductID = od.ProductID
+  WHERE o.OrderDate >= DATEADD(DAY, -30, SYSUTCDATETIME())
+  GROUP BY od.ProductID, p.Name
+  ORDER BY UnitsSold DESC, Revenue DESC;
+GO

--- a/sql/04_procs.sql
+++ b/sql/04_procs.sql
@@ -1,0 +1,56 @@
+USE OnlineStoreDB;
+GO
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+/* Create an order */
+CREATE OR ALTER PROCEDURE dbo.CreateOrder
+  @CustomerID INT,
+  @OrderID INT OUTPUT
+AS
+BEGIN
+  SET NOCOUNT ON;
+  INSERT INTO dbo.Orders(CustomerID) VALUES (@CustomerID);
+  SET @OrderID = SCOPE_IDENTITY();
+END;
+GO
+
+/* Add a line item (validates stock, updates totals & decrements stock) */
+CREATE OR ALTER PROCEDURE dbo.AddOrderItem
+  @OrderID INT,
+  @ProductID INT,
+  @Quantity INT
+AS
+BEGIN
+  SET NOCOUNT ON;
+
+  DECLARE @unit DECIMAL(10,2), @available INT;
+
+  SELECT @unit = Price, @available = StockQuantity
+  FROM dbo.Products WHERE ProductID = @ProductID;
+
+  IF @unit IS NULL
+    THROW 50001, 'Product not found.', 1;
+
+  IF @available < @Quantity
+    THROW 50002, 'Insufficient stock.', 1;
+
+  INSERT INTO dbo.OrderDetails(OrderID, ProductID, Quantity, UnitPrice)
+  VALUES (@OrderID, @ProductID, @Quantity, @unit);
+
+  /* Update order total */
+  UPDATE o
+    SET TotalAmount = (
+      SELECT SUM(Subtotal) FROM dbo.OrderDetails WHERE OrderID = o.OrderID
+    )
+  FROM dbo.Orders o
+  WHERE o.OrderID = @OrderID;
+
+  /* Decrement stock */
+  UPDATE dbo.Products
+    SET StockQuantity = StockQuantity - @Quantity
+  WHERE ProductID = @ProductID;
+END;
+GO

--- a/sql/05_triggers.sql
+++ b/sql/05_triggers.sql
@@ -1,0 +1,43 @@
+USE OnlineStoreDB;
+GO
+
+/* Generic UpdatedAt triggers */
+CREATE OR ALTER TRIGGER trg_Customers_UpdatedAt
+ON dbo.Customers AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  UPDATE c SET UpdatedAt = SYSUTCDATETIME()
+  FROM dbo.Customers c
+  JOIN inserted i ON i.CustomerID = c.CustomerID;
+END;
+GO
+
+CREATE OR ALTER TRIGGER trg_Products_UpdatedAt
+ON dbo.Products AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  UPDATE p SET UpdatedAt = SYSUTCDATETIME()
+  FROM dbo.Products p
+  JOIN inserted i ON i.ProductID = p.ProductID;
+END;
+GO
+
+CREATE OR ALTER TRIGGER trg_Orders_UpdatedAt
+ON dbo.Orders AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  UPDATE o SET UpdatedAt = SYSUTCDATETIME()
+  FROM dbo.Orders o
+  JOIN inserted i ON i.OrderID = o.OrderID;
+END;
+GO
+
+CREATE OR ALTER TRIGGER trg_OrderDetails_UpdatedAt
+ON dbo.OrderDetails AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  UPDATE d SET UpdatedAt = SYSUTCDATETIME()
+  FROM dbo.OrderDetails d
+  JOIN inserted i ON i.OrderDetailID = d.OrderDetailID;
+END;
+GO

--- a/sql/06_migrations.sql
+++ b/sql/06_migrations.sql
@@ -1,0 +1,13 @@
+USE OnlineStoreDB;
+GO
+/* Add Status column if missing */
+IF COL_LENGTH('dbo.Orders','Status') IS NULL
+BEGIN
+  ALTER TABLE dbo.Orders ADD Status NVARCHAR(20) NOT NULL CONSTRAINT DF_Orders_Status DEFAULT ('Open');
+END;
+GO
+
+/* Index for common filters */
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='IX_Orders_Status_OrderDate' AND object_id=OBJECT_ID('dbo.Orders'))
+  CREATE INDEX IX_Orders_Status_OrderDate ON dbo.Orders(Status, OrderDate DESC);
+GO

--- a/sql/07_order_ops.sql
+++ b/sql/07_order_ops.sql
@@ -1,0 +1,85 @@
+USE OnlineStoreDB;
+GO
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+/* Cancel entire order: restock items, delete details, zero total, set Status */
+CREATE OR ALTER PROCEDURE dbo.CancelOrder
+  @OrderID INT
+AS
+BEGIN
+  SET NOCOUNT ON;
+  BEGIN TRY
+    BEGIN TRAN;
+
+    /* Restock all products from the order */
+    UPDATE p
+      SET p.StockQuantity = p.StockQuantity + od.Quantity
+    FROM dbo.Products p
+    JOIN dbo.OrderDetails od ON od.ProductID = p.ProductID
+    WHERE od.OrderID = @OrderID;
+
+    /* Remove details */
+    DELETE FROM dbo.OrderDetails WHERE OrderID = @OrderID;
+
+    /* Zero total + mark status */
+    UPDATE dbo.Orders
+      SET TotalAmount = 0, Status = 'Canceled', UpdatedAt = SYSUTCDATETIME()
+    WHERE OrderID = @OrderID;
+
+    COMMIT TRAN;
+  END TRY
+  BEGIN CATCH
+    IF @@TRANCOUNT > 0 ROLLBACK TRAN;
+    THROW;
+  END CATCH
+END;
+GO
+
+/* Return a single line item: restock qty, remove line, recompute total; mark order Closed if no lines remain */
+CREATE OR ALTER PROCEDURE dbo.ReturnItem
+  @OrderID INT,
+  @OrderDetailID INT
+AS
+BEGIN
+  SET NOCOUNT ON;
+  BEGIN TRY
+    BEGIN TRAN;
+
+    DECLARE @pid INT, @qty INT;
+    SELECT @pid = ProductID, @qty = Quantity
+    FROM dbo.OrderDetails
+    WHERE OrderDetailID = @OrderDetailID AND OrderID = @OrderID;
+
+    IF @pid IS NULL
+      THROW 50010, 'Order detail not found for this order.', 1;
+
+    /* Restock */
+    UPDATE dbo.Products
+      SET StockQuantity = StockQuantity + @qty
+    WHERE ProductID = @pid;
+
+    /* Remove the line */
+    DELETE FROM dbo.OrderDetails WHERE OrderDetailID = @OrderDetailID;
+
+    /* Recompute total */
+    UPDATE o
+      SET TotalAmount = ISNULL((
+        SELECT SUM(Subtotal) FROM dbo.OrderDetails WHERE OrderID = o.OrderID
+      ), 0)
+    FROM dbo.Orders o
+    WHERE o.OrderID = @OrderID;
+
+    /* If no lines remain, mark Closed */
+    IF NOT EXISTS (SELECT 1 FROM dbo.OrderDetails WHERE OrderID = @OrderID)
+      UPDATE dbo.Orders SET Status = 'Closed', UpdatedAt = SYSUTCDATETIME() WHERE OrderID = @OrderID;
+
+    COMMIT TRAN;
+  END TRY
+  BEGIN CATCH
+    IF @@TRANCOUNT > 0 ROLLBACK TRAN;
+    THROW;
+  END CATCH
+END;
+GO

--- a/sql/08_views_status.sql
+++ b/sql/08_views_status.sql
@@ -1,0 +1,15 @@
+USE OnlineStoreDB;
+GO
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+CREATE OR ALTER VIEW dbo.vwOrderSummaryWithStatus AS
+  SELECT
+    o.OrderID, o.CustomerID, o.OrderDate, o.Status,
+    o.TotalAmount,
+    COUNT(od.OrderDetailID) AS LineCount
+  FROM dbo.Orders o
+  LEFT JOIN dbo.OrderDetails od ON od.OrderID = o.OrderID
+  GROUP BY o.OrderID, o.CustomerID, o.OrderDate, o.Status, o.TotalAmount;
+GO

--- a/sql/99_sample_queries.sql
+++ b/sql/99_sample_queries.sql
@@ -1,0 +1,25 @@
+USE OnlineStoreDB;
+GO
+
+/* Last 30 days revenue by day */
+SELECT CAST(OrderDate AS DATE) AS [Day], SUM(TotalAmount) AS Revenue
+FROM dbo.Orders
+WHERE OrderDate >= DATEADD(DAY, -30, SYSUTCDATETIME())
+GROUP BY CAST(OrderDate AS DATE)
+ORDER BY [Day] DESC;
+
+/* Top customers */
+SELECT TOP 10 c.CustomerID, c.Name, SUM(o.TotalAmount) AS Spend
+FROM dbo.Customers c
+JOIN dbo.Orders o ON o.CustomerID = c.CustomerID
+GROUP BY c.CustomerID, c.Name
+ORDER BY Spend DESC;
+
+/* Low stock alerts */
+SELECT ProductID, Name, StockQuantity
+FROM dbo.Products
+WHERE StockQuantity < 10
+ORDER BY StockQuantity ASC;
+
+/* Best sellers (view) */
+SELECT * FROM dbo.vwBestSellers30D ORDER BY UnitsSold DESC;


### PR DESCRIPTION
Adds Dockerized SQL Server plus schema, seed data, views, and order lifecycle procedures.

Highlights:
- Docker: SQL Server 2022 container with healthcheck and mounted /sql + /data
- Schema: Customers, Products, Orders, OrderDetails (Subtotal computed), timestamps + UpdatedAt triggers
- Procs: CreateOrder, AddOrderItem (validates stock & updates totals), ReturnItem, CancelOrder (transactional)
- Views: vwOrderSummary, vwBestSellers30D, vwOrderSummaryWithStatus
- Seed: realistic customers/products/orders; totals verified
- Scripts/Docs: Quickstart snippets; repo ready for SSMS demos
